### PR TITLE
Fixed failed to download 'gnu' archive

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -45,6 +45,10 @@ Use this for files that change often, like cache files. Must end with a slash.")
   "Where package.el and quelpa plugins (and their caches) are stored.
 Must end with a slash.")
 
+
+;;; Uncomment the following line if you got “no match” error after `M-x package-install` on a package on MacOS
+;;; (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")
+
 ;;; Initialize package.el
 (require 'package)
 (setq package--init-file-ensured t


### PR DESCRIPTION
This is apparently a bug in Emacs 26.2 for MacOS. It'll happen on Emacs 25.x and lower too. Anything lower than 26.2.90, really!